### PR TITLE
sslfetch.connections: Format the exception instead of using addition

### DIFF
--- a/sslfetch/connections.py
+++ b/sslfetch/connections.py
@@ -52,7 +52,7 @@ else:
         VERIFY_MSGS = [
             "Failed to import and inject pyopenssl/SNI support into urllib3",
             "Disabling certificate verification",
-            "Error was:" + e
+            "Error was: {0}".format(e)
         ]
         VERIFY_SSL = False
 


### PR DESCRIPTION
Avoid:

  Traceback (most recent call last):
   File "./bin/gkeys", line 42, in <module>
     from gkeys.cli import Main
   File "/.../gentoo-keys/gkeys/cli.py", line 20, in <module>
     from gkeys.actions import Actions, Available_Actions
   File "/.../gentoo-keys/gkeys/actions.py", line 22, in <module>
     from sslfetch.connections import Connector
   File "/.../ssl-fetch/sslfetch/connections.py", line 55, in <module>
     "Error was:" + e
 TypeError: cannot concatenate 'str' and 'exceptions.ImportError' objects
